### PR TITLE
Improve logging

### DIFF
--- a/src/clinical_dbs_annotator/__main__.py
+++ b/src/clinical_dbs_annotator/__main__.py
@@ -11,9 +11,11 @@ import sys
 import PySide6.QtSvg  # noqa: F401 - required to enable SVG rendering in QSS
 from PySide6.QtWidgets import QApplication
 
-from .logging_config import setup_logging
+from .logging_config import setup_bootstrap_logging, setup_logging
 from .utils import get_theme_manager
 from .views import WizardWindow
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> int:
@@ -23,23 +25,28 @@ def main() -> int:
     Returns:
         Exit code (0 for success)
     """
-    app = QApplication(sys.argv)
-
-    app.setApplicationName("Clinical DBS Annotator")
-    app.setOrganizationName("BML")
-
-    setup_logging(app)
-
-    theme_manager = get_theme_manager()
+    setup_bootstrap_logging()
     try:
-        theme_manager.apply_theme(theme_manager.get_current_theme(), app)
-    except Exception as e:
-        logging.warning("Could not load theme: %s", e)
+        app = QApplication(sys.argv)
 
-    window = WizardWindow(app)
-    window.show()
+        app.setApplicationName("Clinical DBS Annotator")
+        app.setOrganizationName("BML")
 
-    return app.exec()
+        setup_logging(app)
+
+        theme_manager = get_theme_manager()
+        try:
+            theme_manager.apply_theme(theme_manager.get_current_theme(), app)
+        except Exception:
+            logger.exception("Could not load current theme")
+
+        window = WizardWindow(app)
+        window.show()
+
+        return app.exec()
+    except Exception:
+        logger.critical("Fatal startup failure", exc_info=True)
+        return 1
 
 
 if __name__ == "__main__":

--- a/src/clinical_dbs_annotator/logging_config.py
+++ b/src/clinical_dbs_annotator/logging_config.py
@@ -1,3 +1,4 @@
+import faulthandler
 import logging
 import platform
 import sys
@@ -17,10 +18,53 @@ from . import __version__
 
 _configured = False
 _log_file_path: Path | None = None
+_crash_log_file = None
+
+
+def _install_exception_hooks() -> None:
+    def exc_hook(exc_type, exc, tb):
+        logging.getLogger("uncaught").critical(
+            "Uncaught exception",
+            exc_info=(exc_type, exc, tb),
+        )
+
+    sys.excepthook = exc_hook
+
+    def thread_exc_hook(args: threading.ExceptHookArgs) -> None:
+        logging.getLogger("uncaught").critical(
+            "Uncaught thread exception",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+
+    threading.excepthook = thread_exc_hook
+
+    def unraisable_hook(args: sys.UnraisableHookArgs) -> None:
+        logging.getLogger("uncaught").error(
+            "Unraisable exception in %r",
+            args.object,
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+
+    sys.unraisablehook = unraisable_hook
+
+
+def setup_bootstrap_logging() -> None:
+    root = logging.getLogger()
+    if root.handlers:
+        _install_exception_hooks()
+        return
+
+    fmt = logging.Formatter("%(asctime)s ¦ %(levelname)s ¦ %(name)s ¦ %(message)s")
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setLevel(logging.INFO)
+    sh.setFormatter(fmt)
+    root.setLevel(logging.DEBUG)
+    root.addHandler(sh)
+    _install_exception_hooks()
 
 
 def setup_logging(_app: QApplication) -> Path:
-    global _configured, _log_file_path
+    global _configured, _log_file_path, _crash_log_file
     if _configured:
         assert _log_file_path is not None
         return _log_file_path
@@ -53,21 +97,7 @@ def setup_logging(_app: QApplication) -> Path:
         sh.setFormatter(fmt)
         root.addHandler(sh)
 
-    def exc_hook(exc_type, exc, tb):
-        logging.getLogger("uncaught").critical(
-            "Uncaught exception",
-            exc_info=(exc_type, exc, tb),
-        )
-
-    sys.excepthook = exc_hook
-
-    def thread_exc_hook(args: threading.ExceptHookArgs) -> None:
-        logging.getLogger("uncaught").critical(
-            "Uncaught thread exception",
-            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
-        )
-
-    threading.excepthook = thread_exc_hook
+    _install_exception_hooks()
 
     def qt_handler(mode: QtMsgType, context: QMessageLogContext, message: str) -> None:
         if mode == QtMsgType.QtDebugMsg:
@@ -86,6 +116,19 @@ def setup_logging(_app: QApplication) -> Path:
         logging.getLogger("qt").log(level, "%s%s", message, suffix)
 
     qInstallMessageHandler(qt_handler)
+    _app.aboutToQuit.connect(
+        lambda: logging.getLogger("clinical_dbs_annotator").info("Application shutdown")
+    )
+
+    crash_log_path = log_dir / "clinical-dbs-annotator-crash.log"
+    try:
+        _crash_log_file = open(crash_log_path, "a", encoding="utf-8")
+        faulthandler.enable(file=_crash_log_file, all_threads=True)
+    except Exception:
+        logging.getLogger("clinical_dbs_annotator").exception(
+            "Failed to enable faulthandler with crash log %s",
+            crash_log_path,
+        )
 
     logging.getLogger("clinical_dbs_annotator").info(
         "Started v%s Python %s | %s | log=%s",

--- a/src/clinical_dbs_annotator/models/session_data.py
+++ b/src/clinical_dbs_annotator/models/session_data.py
@@ -6,6 +6,7 @@ for a clinical DBS programming session, including TSV file writing.
 """
 
 import csv
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import TextIO
@@ -14,6 +15,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from ..config import TIMEZONE, TSV_COLUMNS
 from .clinical_scale import ClinicalScale, SessionScale
 from .stimulation import StimulationParameters
+
+logger = logging.getLogger(__name__)
 
 
 class SessionData:
@@ -82,6 +85,7 @@ class SessionData:
         # Calculate next session_id and block_id
         max_block = -1
         max_session = 0
+        parse_errors = 0
         try:
             with open(file_path, newline="", encoding="utf-8") as f:
                 reader = csv.DictReader(f, delimiter="\t")
@@ -97,10 +101,22 @@ class SessionData:
                         if session_val is not None and session_val != "":
                             max_session = max(max_session, int(float(session_val)))
                     except Exception:
+                        parse_errors += 1
                         continue
         except Exception:
+            logger.warning(
+                "Failed to inspect existing session file before append: %s",
+                file_path,
+                exc_info=True,
+            )
             max_block = -1
             max_session = 0
+        if parse_errors:
+            logger.warning(
+                "Skipped %d malformed rows while opening session file in append mode: %s",
+                parse_errors,
+                file_path,
+            )
 
         if start_block_id is None:
             start_block_id = max_block + 1
@@ -114,6 +130,11 @@ class SessionData:
                 reader = csv.DictReader(f, delimiter="\t")
                 existing_fieldnames = reader.fieldnames
         except Exception:
+            logger.warning(
+                "Failed to read existing TSV headers, using defaults: %s",
+                file_path,
+                exc_info=True,
+            )
             existing_fieldnames = None
 
         self.tsv_fieldnames = existing_fieldnames or list(TSV_COLUMNS)
@@ -128,7 +149,11 @@ class SessionData:
             if Path(file_path).stat().st_size == 0:
                 self.tsv_writer.writeheader()
         except Exception:
-            pass
+            logger.warning(
+                "Failed to initialize TSV header for file: %s",
+                file_path,
+                exc_info=True,
+            )
         self.session_start_time = datetime.now()
 
     def close_file(self) -> None:
@@ -365,6 +390,11 @@ class SessionData:
                     reader = csv.DictReader(f, delimiter="\t")
                     fieldnames = reader.fieldnames
             except Exception:
+                logger.warning(
+                    "Failed reading annotation TSV headers, using defaults: %s",
+                    filepath,
+                    exc_info=True,
+                )
                 fieldnames = None
 
         fieldnames = fieldnames or ["date", "time", "timezone", "annotation"]
@@ -381,7 +411,11 @@ class SessionData:
                 self.tsv_writer.writeheader()
                 self.tsv_file.flush()
         except Exception:
-            pass
+            logger.warning(
+                "Failed to initialize annotation TSV header: %s",
+                filepath,
+                exc_info=True,
+            )
 
     def write_simple_annotation(self, annotation: str) -> None:
         """

--- a/src/clinical_dbs_annotator/utils/longitudinal_exporter.py
+++ b/src/clinical_dbs_annotator/utils/longitudinal_exporter.py
@@ -6,6 +6,7 @@ longitudinal report in Word or PDF format, with best-entry highlighting
 based on user-selected scale optimization preferences.
 """
 
+import logging
 import os
 import re
 import tempfile
@@ -23,6 +24,8 @@ from PySide6.QtWidgets import QFileDialog, QMessageBox, QWidget
 from .. import __app_name__, __version__
 from ..config import PLACEHOLDERS
 from ..config_electrode_models import ELECTRODE_MODELS, MANUFACTURERS, ContactState
+
+logger = logging.getLogger(__name__)
 
 
 class LongitudinalExporter:
@@ -72,9 +75,10 @@ class LongitudinalExporter:
                 parent, "Export Completed", f"Report saved:\n{file_path}"
             )
             return True
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to export longitudinal report to Word")
             QMessageBox.critical(
-                parent, "Export Error", f"Failed to export report:\n{e}"
+                parent, "Export Error", "Failed to export report.\nSee log for details."
             )
             return False
 
@@ -114,15 +118,20 @@ class LongitudinalExporter:
                 try:
                     os.unlink(docx_tmp)
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to remove temporary Word file after PDF export: %s",
+                        docx_tmp,
+                        exc_info=True,
+                    )
 
             self._show_transient_message(
                 parent, "Export Completed", f"Report saved:\n{pdf_path}"
             )
             return True
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to export longitudinal report to PDF")
             QMessageBox.critical(
-                parent, "Export Error", f"Failed to export report:\n{e}"
+                parent, "Export Error", "Failed to export report.\nSee log for details."
             )
             return False
 
@@ -158,20 +167,37 @@ class LongitudinalExporter:
                 # If no date info available, return a very old date to put it at the end
                 return pd.Timestamp("1900-01-01")
             except Exception:
+                logger.warning(
+                    "Failed to derive datetime from file, using fallback ordering: %s",
+                    path,
+                    exc_info=True,
+                )
                 return pd.Timestamp("1900-01-01")
 
         # Sort files from oldest to newest
         file_paths = sorted(file_paths, key=get_file_datetime)
 
         frames = []
+        read_failures = 0
         for path in file_paths:
             try:
                 df = pd.read_csv(path, sep="\t")
                 # Tag each row with its source file for traceability
                 df["_source_file"] = os.path.basename(path)
                 frames.append(df)
-            except Exception as e:
-                print(f"[WARNING] Could not read {path}: {e}")
+            except Exception:
+                read_failures += 1
+                logger.warning(
+                    "Could not read longitudinal input file: %s", path, exc_info=True
+                )
+
+        if read_failures:
+            logger.warning(
+                "Longitudinal report input read summary: total_files=%d read_failures=%d loaded=%d",
+                len(file_paths),
+                read_failures,
+                len(frames),
+            )
 
         if not frames:
             return False
@@ -553,6 +579,11 @@ class LongitudinalExporter:
                     try:
                         run.add_picture(png, width=Inches(1.15))
                     except Exception:
+                        logger.debug(
+                            "Failed adding electrode image to report table: %s",
+                            png,
+                            exc_info=True,
+                        )
                         pass
 
             # Cleanup temp PNG files
@@ -560,7 +591,11 @@ class LongitudinalExporter:
                 try:
                     os.unlink(pth)
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Failed to delete temporary electrode image: %s",
+                        pth,
+                        exc_info=True,
+                    )
 
             doc.add_paragraph("")
 
@@ -1052,8 +1087,11 @@ class LongitudinalExporter:
             win.close()
             del win
 
-        except Exception as e:
-            doc.add_paragraph(f"Chart generation error: {e}")
+        except Exception:
+            logger.exception("Failed to generate longitudinal scale trend chart")
+            doc.add_paragraph(
+                "Chart generation error. Please check application logs for details."
+            )
 
     # ------------------------------------------------------------------
     # Data helpers
@@ -1220,6 +1258,7 @@ class LongitudinalExporter:
             )
             return best, second
         except Exception:
+            logger.exception("Failed to rank best/second-best longitudinal entries")
             return [], []
 
     # ------------------------------------------------------------------
@@ -1343,6 +1382,7 @@ class LongitudinalExporter:
             cropped.save(tmp.name, "PNG")
             return tmp.name
         except Exception:
+            logger.exception("Failed to render electrode image for report")
             return None
 
     @staticmethod

--- a/src/clinical_dbs_annotator/utils/session_exporter.py
+++ b/src/clinical_dbs_annotator/utils/session_exporter.py
@@ -5,6 +5,7 @@ This module provides functionality to export session data to Word and PDF.
 """
 
 import csv
+import logging
 import os
 import shutil
 import subprocess
@@ -25,6 +26,8 @@ from .. import __app_name__, __version__
 from ..config import PLACEHOLDERS
 from ..config_electrode_models import ELECTRODE_MODELS, MANUFACTURERS, ContactState
 from ..models import ElectrodeCanvas
+
+logger = logging.getLogger(__name__)
 
 
 class SessionExporter:
@@ -242,6 +245,10 @@ class SessionExporter:
                 return pd.read_csv(self.session_data.file_path, sep="\t")
             return None
         except Exception:
+            logger.exception(
+                "Failed to read session data from TSV: %s",
+                getattr(self.session_data, "file_path", None),
+            )
             return None
 
     def _normalize_block_id_column(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -367,7 +374,7 @@ class SessionExporter:
                 else:
                     duration_str = f"{total_mins} min"
         except Exception:
-            pass
+            logger.debug("Failed to compute session duration", exc_info=True)
 
         # Number of configurations tested
         df_normalized = self._normalize_block_id_column(df)
@@ -424,7 +431,10 @@ class SessionExporter:
                     else:
                         pw_r = val
         except Exception:
-            pass
+            logger.warning(
+                "Failed to compute programming summary parameter ranges",
+                exc_info=True,
+            )
 
         # Add summary paragraphs
         summary_items = [
@@ -695,6 +705,10 @@ class SessionExporter:
                     scale_name_lines += [""] * (max_len - len(scale_name_lines))
                     scale_value_lines += [""] * (max_len - len(scale_value_lines))
                 except Exception:
+                    logger.debug(
+                        "Failed to split multiline scale cells for report rendering",
+                        exc_info=True,
+                    )
                     scale_name_lines = None
                     scale_value_lines = None
 
@@ -1062,8 +1076,11 @@ class SessionExporter:
             win.close()
             del win
 
-        except Exception as e:
-            doc.add_paragraph(f"Chart generation error: {e}")
+        except Exception:
+            logger.exception("Failed to generate session scale timeline chart")
+            doc.add_paragraph(
+                "Chart generation error. Please check application logs for details."
+            )
 
     def _column_header(self, col: str) -> str:
         """Map an internal column name to a human-readable table header."""
@@ -1091,6 +1108,9 @@ class SessionExporter:
                 bid = pd.to_numeric(df["block_id"], errors="coerce")
                 return df.loc[bid.idxmax()]
             except Exception:
+                logger.debug(
+                    "Fallback to last row after block_id parse failure", exc_info=True
+                )
                 return df.iloc[-1]
         return df.iloc[-1]
 
@@ -1204,6 +1224,7 @@ class SessionExporter:
             return best_blocks, second_best_blocks
 
         except Exception:
+            logger.exception("Failed to rank best/second-best session blocks")
             return [], []
 
     def _highlight_cells_green(self, row_cells, intensity: str = "best") -> None:
@@ -1222,7 +1243,9 @@ class SessionExporter:
                 shading_elm.set(qn("w:fill"), color)
                 cell._tc.get_or_add_tcPr().append(shading_elm)
             except Exception:
-                pass
+                logger.debug(
+                    "Failed to cleanup temporary electrode image", exc_info=True
+                )
 
     def _set_cell_border_top(self, cell, sz=12):
         """Set top border of a cell to specified size (in eighths of a point)."""
@@ -1607,7 +1630,11 @@ class SessionExporter:
                 try:
                     os.unlink(docx_path)
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to remove temporary Word file after PDF export: %s",
+                        docx_path,
+                        exc_info=True,
+                    )
 
             self._show_transient_message(
                 parent,
@@ -1617,11 +1644,12 @@ class SessionExporter:
             )
             return True
 
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to export session data to PDF")
             QMessageBox.critical(
                 parent,
                 "Export Error",
-                f"Failed to export session data to PDF:\n{str(e)}",
+                "Failed to export session data to PDF.\nSee log for details.",
             )
             return False
 
@@ -1693,11 +1721,12 @@ class SessionExporter:
             )
             return True
 
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to export session data to Word")
             QMessageBox.critical(
                 parent,
                 "Export Error",
-                f"Failed to export session data to Word:\n{str(e)}",
+                "Failed to export session data to Word.\nSee log for details.",
             )
             return False
 
@@ -1804,6 +1833,10 @@ class SessionExporter:
             try:
                 file_path = self.session_data.tsv_file.name
             except Exception:
+                logger.warning(
+                    "Failed to resolve simple annotation file path from active handle",
+                    exc_info=True,
+                )
                 file_path = None
         if not file_path or not os.path.exists(file_path):
             return []
@@ -1821,6 +1854,10 @@ class SessionExporter:
                         try:
                             kk = str(k).strip().lstrip("\ufeff").lower()
                         except Exception:
+                            logger.debug(
+                                "Skipping malformed annotation key while reading TSV row",
+                                exc_info=True,
+                            )
                             continue
                         norm[kk] = v
 
@@ -1854,11 +1891,18 @@ class SessionExporter:
                             t = str(vals[0] or "") if len(vals) >= 1 else ""
                             a = str(vals[1] or "") if len(vals) >= 2 else ""
                         except Exception:
+                            logger.debug(
+                                "Failed fallback parsing for annotation row",
+                                exc_info=True,
+                            )
                             t, a = "", ""
 
                     if a.strip() or t.strip():
                         items.append((t, a))
         except Exception:
+            logger.exception(
+                "Failed to read simple annotations from TSV: %s", file_path
+            )
             return []
         return items
 
@@ -1899,7 +1943,10 @@ class SessionExporter:
                 try:
                     self.session_data.tsv_file.flush()
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to flush annotation TSV before Word export",
+                        exc_info=True,
+                    )
 
             from PySide6.QtWidgets import QFileDialog
 
@@ -1939,11 +1986,12 @@ class SessionExporter:
                 msecs=2000,
             )
             return True
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to export annotations to Word")
             QMessageBox.critical(
                 parent,
                 "Export Error",
-                f"Failed to export annotations to Word:\n{str(e)}",
+                "Failed to export annotations to Word.\nSee log for details.",
             )
             return False
 
@@ -1962,7 +2010,10 @@ class SessionExporter:
                 try:
                     self.session_data.tsv_file.flush()
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to flush annotation TSV before PDF export",
+                        exc_info=True,
+                    )
 
             from PySide6.QtWidgets import QFileDialog
 
@@ -2002,7 +2053,11 @@ class SessionExporter:
                 try:
                     os.unlink(docx_path)
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to remove temporary annotations Word file: %s",
+                        docx_path,
+                        exc_info=True,
+                    )
 
             self._show_transient_message(
                 parent,
@@ -2011,10 +2066,11 @@ class SessionExporter:
                 msecs=2000,
             )
             return True
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to export annotations to PDF")
             QMessageBox.critical(
                 parent,
                 "Export Error",
-                f"Failed to export annotations to PDF:\n{str(e)}",
+                "Failed to export annotations to PDF.\nSee log for details.",
             )
             return False

--- a/src/clinical_dbs_annotator/utils/theme_manager.py
+++ b/src/clinical_dbs_annotator/utils/theme_manager.py
@@ -5,6 +5,7 @@ This module provides a centralized theme management system that allows
 switching between dark and light themes at runtime.
 """
 
+import logging
 import os
 from enum import Enum
 
@@ -12,6 +13,8 @@ from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QApplication, QToolTip
 
 from .resources import resource_path
+
+logger = logging.getLogger(__name__)
 
 
 class Theme(Enum):
@@ -139,7 +142,7 @@ class ThemeManager:
             self._current_theme = theme
             self._save_theme()
         except FileNotFoundError as e:
-            print(f"Warning: Could not load theme: {e}")
+            logger.warning("Could not load theme stylesheet: %s", e)
             # Fallback to no stylesheet
             app.setStyleSheet("")
 
@@ -199,7 +202,7 @@ class ThemeManager:
             if match:
                 return match.group(1)
         except Exception:
-            pass
+            logger.exception("Failed to resolve theme color '%s'", color_name)
         return "#888888"
 
     def get_theme_icon(self, theme: Theme) -> str:

--- a/src/clinical_dbs_annotator/views/longitudinal_report_view.py
+++ b/src/clinical_dbs_annotator/views/longitudinal_report_view.py
@@ -7,6 +7,7 @@ longitudinal report.
 """
 
 import csv
+import logging
 import os
 import re
 import typing
@@ -27,6 +28,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class FileDropZone(QWidget):
@@ -357,6 +360,8 @@ class LongitudinalReportView(QWidget):
             List of (scale_name, min_value, max_value) tuples with observed ranges.
         """
         scale_values: dict[str, list[float]] = {}
+        read_failures: list[str] = []
+        invalid_value_count = 0
 
         for path in file_paths:
             try:
@@ -373,16 +378,30 @@ class LongitudinalReportView(QWidget):
                         try:
                             val = float(scale_value)
                         except ValueError:
+                            invalid_value_count += 1
                             continue
                         if scale_name not in scale_values:
                             scale_values[scale_name] = []
                         scale_values[scale_name].append(val)
-            except Exception as e:
-                print(f"[WARNING] Could not read {path}: {e}")
+            except Exception:
+                read_failures.append(path)
+                logger.warning(
+                    "Could not read longitudinal scales from file %s",
+                    path,
+                    exc_info=True,
+                )
 
         result = []
         for name, values in scale_values.items():
             min_v = str(min(values))
             max_v = str(max(values))
             result.append((name, min_v, max_v))
+
+        if read_failures or invalid_value_count:
+            logger.warning(
+                "Extracted longitudinal scales from %d files; read_failures=%d; invalid_values=%d",
+                len(file_paths),
+                len(read_failures),
+                invalid_value_count,
+            )
         return result

--- a/src/clinical_dbs_annotator/views/step1_view.py
+++ b/src/clinical_dbs_annotator/views/step1_view.py
@@ -5,6 +5,7 @@ This module contains the view for the first step of the wizard where users
 configure initial settings, stimulation parameters, and clinical scales.
 """
 
+import logging
 import os
 from collections.abc import Callable
 from datetime import datetime
@@ -59,6 +60,8 @@ from ..utils.program_config_manager import (
 )
 from ..utils.scale_preset_manager import get_scale_preset_manager
 from .base_view import BaseStepView
+
+logger = logging.getLogger(__name__)
 
 
 class Step1View(BaseStepView):
@@ -797,20 +800,15 @@ class Step1View(BaseStepView):
         if not left_model or not right_model:
             return
 
-        print("\n" + "=" * 60)
-        print("DBS STIMULATION CONFIGURATION")
-        print("=" * 60)
-        print(f"Model: {left_model.name}")
-        print(f"Timestamp: {datetime.now().astimezone().strftime('%Y-%m-%d %H:%M:%S')}")
-        print()
-
-        print(
-            f"LEFT  Anode: {self.get_left_anode_text()} | Cathode: {self.get_left_cathode_text()}"
+        logger.info(
+            "DBS stimulation configuration | model=%s | timestamp=%s | left_anode=%s | left_cathode=%s | right_anode=%s | right_cathode=%s",
+            left_model.name,
+            datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S"),
+            self.get_left_anode_text(),
+            self.get_left_cathode_text(),
+            self.get_right_anode_text(),
+            self.get_right_cathode_text(),
         )
-        print(
-            f"RIGHT Anode: {self.get_right_anode_text()} | Cathode: {self.get_right_cathode_text()}"
-        )
-        print("=" * 60 + "\n")
 
     def _create_upload_tsv_group(self) -> QGroupBox:
         """Create the file upload group with drop zone, Open, and New buttons."""
@@ -1730,8 +1728,8 @@ class Step1View(BaseStepView):
         try:
             preset_manager = get_scale_preset_manager()
             preset_manager.save_clinical_presets(new_presets)
-        except Exception as e:
-            print(f"Error saving presets: {e}")
+        except Exception:
+            logger.exception("Failed to save clinical presets")
 
         # Check if any currently displayed preset was modified or deleted
         current_scales = []

--- a/src/clinical_dbs_annotator/views/step2_view.py
+++ b/src/clinical_dbs_annotator/views/step2_view.py
@@ -5,6 +5,7 @@ This module contains the view for the second step where users configure
 the session tracking scales that will be used during the programming session.
 """
 
+import logging
 from collections.abc import Callable
 
 from PySide6.QtCore import QSize, Qt
@@ -26,6 +27,8 @@ from ..config import PLACEHOLDERS, PRESET_BUTTONS
 from ..ui.session_scales_settings_dialog import SessionScalesSettingsDialog
 from ..utils.scale_preset_manager import get_scale_preset_manager
 from .base_view import BaseStepView
+
+logger = logging.getLogger(__name__)
 
 
 class Step2View(BaseStepView):
@@ -151,8 +154,8 @@ class Step2View(BaseStepView):
         try:
             preset_manager = get_scale_preset_manager()
             preset_manager.save_session_presets(new_presets)
-        except Exception as e:
-            print(f"Error saving session presets: {e}")
+        except Exception:
+            logger.exception("Failed to save session presets")
 
         self._refresh_preset_buttons()
 

--- a/src/clinical_dbs_annotator/views/step3_view.py
+++ b/src/clinical_dbs_annotator/views/step3_view.py
@@ -5,6 +5,8 @@ This module contains the view for the third step where users actively record
 session data including stimulation parameters and scale values.
 """
 
+import logging
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QDoubleValidator, QIntValidator
 from PySide6.QtWidgets import (
@@ -48,6 +50,8 @@ from ..utils.program_config_manager import (
     get_program_config_manager,
 )
 from .base_view import BaseStepView
+
+logger = logging.getLogger(__name__)
 
 
 class Step3View(BaseStepView):
@@ -838,7 +842,11 @@ class Step3View(BaseStepView):
             try:
                 self.group_combo.setCurrentText(str(program))
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to restore Step 3 program selection: %s",
+                    program,
+                    exc_info=True,
+                )
 
         if self.left_canvas.model:
             self._apply_contact_text_to_canvas(
@@ -879,8 +887,10 @@ class Step3View(BaseStepView):
 
         canvas.contact_states.clear()
         canvas.case_state = ContactState.OFF
+        parse_errors = 0
 
         def apply_tokens(text: str, state: int) -> None:
+            nonlocal parse_errors
             if not text:
                 return
             for token in text.split("_"):
@@ -908,6 +918,7 @@ class Step3View(BaseStepView):
                             else:
                                 canvas.contact_states[(idx, 0)] = state
                     except Exception:
+                        parse_errors += 1
                         continue
                     continue
 
@@ -916,6 +927,7 @@ class Step3View(BaseStepView):
                     try:
                         idx = int(idx_str)
                     except Exception:
+                        parse_errors += 1
                         continue
 
                     if model.is_directional:
@@ -929,6 +941,7 @@ class Step3View(BaseStepView):
                     try:
                         idx = int(token[:-1])
                     except Exception:
+                        parse_errors += 1
                         continue
                     seg_char = token[-1].lower()
                     seg_map = {"a": 0, "b": 1, "c": 2}
@@ -937,6 +950,11 @@ class Step3View(BaseStepView):
 
         apply_tokens(anode_text, ContactState.ANODIC)
         apply_tokens(cathode_text, ContactState.CATHODIC)
+        if parse_errors:
+            logger.warning(
+                "Skipped %d invalid contact tokens while restoring stimulation configuration",
+                parse_errors,
+            )
 
         is_valid, _ = StimulationRule.validate_configuration(
             canvas.contact_states, canvas.case_state

--- a/src/clinical_dbs_annotator/views/wizard_window.py
+++ b/src/clinical_dbs_annotator/views/wizard_window.py
@@ -5,6 +5,7 @@ This module contains the main window that manages the wizard flow,
 navigation, and coordinates views with the controller.
 """
 
+import logging
 import os
 import typing
 
@@ -49,6 +50,8 @@ from .step0_view import Step0View
 from .step1_view import Step1View
 from .step2_view import Step2View
 from .step3_view import Step3View
+
+logger = logging.getLogger(__name__)
 
 
 class WizardWindow(QWidget):
@@ -940,11 +943,8 @@ class WizardWindow(QWidget):
             try:
                 self.controller.prepare_step3(self.step3_view)
                 self._step3_prepared = True
-            except Exception as e:
-                print(f"[ERROR] prepare_step3 retry failed: {e}")
-                import traceback
-
-                traceback.print_exc()
+            except Exception:
+                logger.exception("Step 3 preparation retry failed")
         else:
             # Only refresh scales if definitions changed; keep everything else as-is
             self.controller.refresh_step3_scales(self.step3_view)


### PR DESCRIPTION
- logging_config.py: setup_bootstrap_logging() (stderr + hooks before full setup), setup_logging() with rotating file + optional stderr, sys.excepthook / threading.excepthook / sys.unraisablehook, Qt message handler, aboutToQuit shutdown line, faulthandler → clinical-dbs-annotator-crash.log.
- __main__.py: Bootstrap logging first, then try/except around startup with logger.critical on fatal failure.
- Views / theme: Module loggers; print/traceback replaced in wizard, step1/2, longitudinal view, theme manager; balanced summaries where useful.
- Exporters / model / step3: Logging on read failures, export errors, chart failures, TSV append issues, and token/summary warnings as planned.