### PR TITLE
Add type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Lint
+name: CI - Lint and Type Check
 
 on:
   push:
@@ -17,21 +17,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up uv with Python
+      - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
         with:
           python-version: "3.14"
           enable-cache: true
 
-      - name: Sync dependencies (locked, dev)
+      - name: Sync dependencies
         run: |
           uv sync --locked --dev
 
-      - name: Run ruff (as in pre-commit)
+      - name: Lint
         run: |
           uv run ruff check --exclude tests .
 
-      - name: Run ruff format (check)
+      - name: Format
         run: |
           uv run ruff format --check --exclude tests .
 
@@ -40,4 +40,26 @@ jobs:
       # - name: Run pytest
       #   run: |
       #     uv run pytest
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        with:
+          python-version: "3.14"
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: |
+          uv sync --locked --dev
+
+      - name: Type check
+        run: |
+          uv run ty check src
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,11 @@ repos:
       - id: ruff-format
       - id: ruff-check
         args: ["--fix", "--exclude", "tests"]
+
+  - repo: local
+    hooks:
+      - id: ty-check
+        name: ty check (src)
+        entry: uv run ty check src
+        language: system
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dev = [
     "ruff>=0.1.0",
     # "mypy>=1.8.0",
     "pre-commit>=3.6",
+    "ty>=0.0.30",
+    "pandas-stubs>=3.0.0.260204",
 ]
 build = [
     "pyinstaller>=6.15.0",
@@ -121,3 +123,6 @@ strict_optional = true
 [[tool.mypy.overrides]]
 module = "PySide6.*"
 ignore_missing_imports = true
+
+[tool.ty.rules]
+unresolved-attribute = "ignore"

--- a/src/clinical_dbs_annotator/controllers/wizard_controller.py
+++ b/src/clinical_dbs_annotator/controllers/wizard_controller.py
@@ -476,12 +476,17 @@ class WizardController:
 
         # Read the TSV file and filter out rows with the last block_id
         file_path = self.session_data.file_path
+        if file_path is None:
+            QMessageBox.warning(
+                view, "Error", "No file path is associated with this session."
+            )
+            return
         rows_to_keep = []
         rows_to_delete = []
 
         with open(file_path, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f, delimiter="\t")
-            fieldnames = reader.fieldnames
+            fieldnames = list(reader.fieldnames or [])
 
             for row in reader:
                 block_id = row.get("block_id", "")
@@ -528,11 +533,11 @@ class WizardController:
             parent,
             "Confirm Close Session",
             "Are you sure you want to close the current session? The session will be saved before closing.",
-            QMessageBox.Ok | QMessageBox.Cancel,
-            QMessageBox.Cancel,
+            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
         )
 
-        if reply == QMessageBox.Ok:
+        if reply == QMessageBox.StandardButton.Ok:
             self.session_data.close_file()
             parent.close()
 

--- a/src/clinical_dbs_annotator/logging_config.py
+++ b/src/clinical_dbs_annotator/logging_config.py
@@ -5,6 +5,7 @@ import sys
 import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from types import TracebackType
 
 from PySide6.QtCore import (
     QMessageLogContext,
@@ -21,8 +22,24 @@ _log_file_path: Path | None = None
 _crash_log_file = None
 
 
+def _safe_exc_info(
+    exc_type: type[BaseException],
+    exc_value: BaseException | None,
+    exc_traceback: TracebackType | None,
+) -> (
+    tuple[type[BaseException], BaseException, TracebackType | None]
+    | tuple[None, None, None]
+):
+    """Normalize exception tuple for logging APIs that require non-optional exception values."""
+    if exc_value is None:
+        return (None, None, None)
+    return (exc_type, exc_value, exc_traceback)
+
+
 def _install_exception_hooks() -> None:
-    def exc_hook(exc_type, exc, tb):
+    def exc_hook(
+        exc_type: type[BaseException], exc: BaseException, tb: TracebackType | None
+    ) -> None:
         logging.getLogger("uncaught").critical(
             "Uncaught exception",
             exc_info=(exc_type, exc, tb),
@@ -33,7 +50,7 @@ def _install_exception_hooks() -> None:
     def thread_exc_hook(args: threading.ExceptHookArgs) -> None:
         logging.getLogger("uncaught").critical(
             "Uncaught thread exception",
-            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+            exc_info=_safe_exc_info(args.exc_type, args.exc_value, args.exc_traceback),
         )
 
     threading.excepthook = thread_exc_hook
@@ -42,7 +59,7 @@ def _install_exception_hooks() -> None:
         logging.getLogger("uncaught").error(
             "Unraisable exception in %r",
             args.object,
-            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+            exc_info=_safe_exc_info(args.exc_type, args.exc_value, args.exc_traceback),
         )
 
     sys.unraisablehook = unraisable_hook

--- a/src/clinical_dbs_annotator/models/session_data.py
+++ b/src/clinical_dbs_annotator/models/session_data.py
@@ -128,7 +128,7 @@ class SessionData:
         try:
             with open(file_path, newline="", encoding="utf-8") as f:
                 reader = csv.DictReader(f, delimiter="\t")
-                existing_fieldnames = reader.fieldnames
+                existing_fieldnames = list(reader.fieldnames or [])
         except Exception:
             logger.warning(
                 "Failed to read existing TSV headers, using defaults: %s",
@@ -388,7 +388,7 @@ class SessionData:
             try:
                 with open(filepath, newline="", encoding="utf-8") as f:
                     reader = csv.DictReader(f, delimiter="\t")
-                    fieldnames = reader.fieldnames
+                    fieldnames = list(reader.fieldnames or [])
             except Exception:
                 logger.warning(
                     "Failed reading annotation TSV headers, using defaults: %s",

--- a/src/clinical_dbs_annotator/ui/widgets.py
+++ b/src/clinical_dbs_annotator/ui/widgets.py
@@ -7,7 +7,7 @@ section labels, and horizontal lines.
 
 import typing
 
-from PySide6.QtCore import QEvent, QSize, Qt, Signal
+from PySide6.QtCore import QByteArray, QEvent, QSize, Qt, Signal
 from PySide6.QtGui import QIcon, QPixmap
 from PySide6.QtWidgets import (
     QFrame,
@@ -168,10 +168,10 @@ class IncrementWidget(QWidget):
         """
         btn = QPushButton()
         btn.setIcon(create_arrow_icon(direction, double))
-        btn.setIconSize(QSize(*ICON_SIZES["increment"]))
-        btn.setFixedSize(
-            BUTTON_SIZES["increment"]["width"], BUTTON_SIZES["increment"]["height"]
-        )
+        icon_width, icon_height = typing.cast(tuple[int, int], ICON_SIZES["increment"])
+        btn.setIconSize(QSize(icon_width, icon_height))
+        increment_size = typing.cast(dict[str, int], BUTTON_SIZES["increment"])
+        btn.setFixedSize(increment_size["width"], increment_size["height"])
         btn.setCursor(Qt.PointingHandCursor)
         btn.setStyleSheet(
             """
@@ -353,7 +353,7 @@ class ScaleProgressWidget(QWidget):
                 """
 
         pixmap = QPixmap()
-        pixmap.loadFromData(bytes(svg, encoding="utf-8"), "SVG")
+        pixmap.loadFromData(QByteArray(svg.encode("utf-8")))
         return QIcon(pixmap)
 
     def _create_x_icon(self) -> QIcon:
@@ -366,7 +366,7 @@ class ScaleProgressWidget(QWidget):
         </svg>
         """
         pixmap = QPixmap()
-        pixmap.loadFromData(bytes(svg, encoding="utf-8"), "SVG")
+        pixmap.loadFromData(QByteArray(svg.encode("utf-8")))
         return QIcon(pixmap)
 
     @typing.override
@@ -437,26 +437,22 @@ class ScaleProgressWidget(QWidget):
             self.valueChanged.emit(self._value)
 
     # Public API (mirrors old InteractiveProgressBar)
-    @typing.override
-    def setMinimum(self, value: int) -> None:
+    def setMinimum(self, value: int) -> None:  # noqa: N802
         """Set the minimum internal value."""
         self._minimum = int(value)
         self.progress_bar.setMinimum(int(value))
 
-    @typing.override
-    def setMaximum(self, value: int) -> None:
+    def setMaximum(self, value: int) -> None:  # noqa: N802
         """Set the maximum internal value."""
         self._maximum = int(value)
         self.progress_bar.setMaximum(int(value))
 
-    @typing.override
-    def setValue(self, value: int) -> None:
+    def setValue(self, value: int) -> None:  # noqa: N802
         """Set the current value and update the progress bar."""
         self._value = int(value)
         self.progress_bar.setValue(int(value))
 
-    @typing.override
-    def setFormat(self, format_str: str) -> None:
+    def setFormat(self, format_str: str) -> None:  # noqa: N802
         """Set the text format displayed on the progress bar."""
         self.progress_bar.setFormat(format_str)
 
@@ -477,8 +473,7 @@ class ScaleProgressWidget(QWidget):
         """Return the current internal value."""
         return self._value
 
-    @typing.override
-    def isDisabled(self) -> bool:
+    def isDisabled(self) -> bool:  # noqa: N802
         """Return True if the widget is in disabled state."""
         return self._disabled
 

--- a/src/clinical_dbs_annotator/utils/graphics.py
+++ b/src/clinical_dbs_annotator/utils/graphics.py
@@ -5,7 +5,7 @@ This module provides functions for creating icons, rounded images,
 and button animations.
 """
 
-from PySide6.QtCore import QRectF, Qt, QTimer
+from PySide6.QtCore import QByteArray, QRectF, Qt, QTimer
 from PySide6.QtGui import QIcon, QPainter, QPainterPath, QPixmap
 
 from ..config import BUTTON_PULSE_COUNT, BUTTON_PULSE_DURATION
@@ -54,7 +54,7 @@ def create_arrow_icon(direction: str = "up", double: bool = False) -> QIcon:
             """
 
     pixmap = QPixmap()
-    pixmap.loadFromData(bytes(svg, encoding="utf-8"), "SVG")
+    pixmap.loadFromData(QByteArray(svg.encode("utf-8")))
     return QIcon(pixmap)
 
 

--- a/src/clinical_dbs_annotator/utils/longitudinal_exporter.py
+++ b/src/clinical_dbs_annotator/utils/longitudinal_exporter.py
@@ -14,6 +14,7 @@ from datetime import datetime
 
 import pandas as pd
 from docx import Document
+from docx.document import Document as DocumentType
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
@@ -288,7 +289,7 @@ class LongitudinalExporter:
     # ------------------------------------------------------------------
 
     def _add_sessions_overview(
-        self, doc: Document, df: pd.DataFrame, file_paths: list[str]
+        self, doc: DocumentType, df: pd.DataFrame, file_paths: list[str]
     ) -> None:
         """Add a summary table listing each session file with date and entry count."""
         doc.add_heading("Sessions Overview", level=1)
@@ -398,7 +399,7 @@ class LongitudinalExporter:
             )
 
     def _add_electrode_config_section(
-        self, doc: Document, df_all: pd.DataFrame, file_paths: list[str]
+        self, doc: DocumentType, df_all: pd.DataFrame, file_paths: list[str]
     ) -> None:
         """Add per-file electrode configuration (Initial / Final, Left / Right).
 
@@ -600,7 +601,7 @@ class LongitudinalExporter:
             doc.add_paragraph("")
 
     def _add_programming_summary(
-        self, doc: Document, df_all: pd.DataFrame, file_paths: list[str]
+        self, doc: DocumentType, df_all: pd.DataFrame, file_paths: list[str]
     ) -> None:
         """Add a per-session programming summary table."""
         if df_all is None or df_all.empty:
@@ -687,7 +688,7 @@ class LongitudinalExporter:
 
     def _add_longitudinal_data_table(
         self,
-        doc: Document,
+        doc: DocumentType,
         df_session: pd.DataFrame,
         file_paths: list[str] | None = None,
     ) -> None:
@@ -745,9 +746,10 @@ class LongitudinalExporter:
 
         # Column widths
         section = doc.sections[0]
-        page_w = (
-            section.page_width - section.left_margin - section.right_margin
-        ) / 914400
+        page_width = int(section.page_width or 0)
+        left_margin = int(section.left_margin or 0)
+        right_margin = int(section.right_margin or 0)
+        page_w = (page_width - left_margin - right_margin) / 914400
         base_w = {
             "date": 0.65,
             "laterality": 0.25,
@@ -838,7 +840,7 @@ class LongitudinalExporter:
         self._add_table_legend(doc, best_ids, second_ids)
 
     def _add_scales_timeline_chart(
-        self, doc: Document, df_session: pd.DataFrame
+        self, doc: DocumentType, df_session: pd.DataFrame
     ) -> None:
         """Add a rainbow-colored timeline chart of scale trends with a general index line."""
         import math as _math
@@ -1080,7 +1082,7 @@ class LongitudinalExporter:
             qbuf.open(QIODevice.OpenModeFlag.WriteOnly)
             pixmap.save(qbuf, "PNG")
             qbuf.close()
-            img_buf = BytesIO(bytes(qbuf.data()))
+            img_buf = BytesIO(qbuf.data().data())
             doc.add_picture(img_buf, width=Inches(6))
             doc.add_paragraph()
             img_buf.close()
@@ -1288,7 +1290,7 @@ class LongitudinalExporter:
         """Render electrode configuration to a temporary PNG file."""
         try:
             from PySide6.QtGui import QColor as _QColor
-            from PySide6.QtGui import QPainter, QPixmap
+            from PySide6.QtGui import QPixmap
 
             from ..models import ElectrodeCanvas
 
@@ -1308,7 +1310,7 @@ class LongitudinalExporter:
             canvas.contact_states.clear()
             canvas.case_state = ContactState.OFF
 
-            def apply_tokens(text: str, state: ContactState) -> None:
+            def apply_tokens(text: str, state: int) -> None:
                 if not text:
                     return
                 for token in str(text).split("_"):
@@ -1341,16 +1343,6 @@ class LongitudinalExporter:
             apply_tokens(anode_text, ContactState.ANODIC)
             apply_tokens(cathode_text, ContactState.CATHODIC)
             canvas.update()
-
-            # Render with white background
-            original_paint = canvas.paintEvent
-
-            def white_bg_paint(event):
-                painter = QPainter(canvas)
-                painter.fillRect(canvas.rect(), Qt.white)
-                original_paint(event)
-
-            canvas.paintEvent = white_bg_paint
 
             pixmap = QPixmap(canvas.size())
             pixmap.fill(Qt.white)
@@ -1469,7 +1461,7 @@ class LongitudinalExporter:
             pass
 
     def _add_table_legend(
-        self, doc: Document, best_ids: list, second_ids: list
+        self, doc: DocumentType, best_ids: list, second_ids: list
     ) -> None:
         if not best_ids and not second_ids:
             return

--- a/src/clinical_dbs_annotator/utils/responsive.py
+++ b/src/clinical_dbs_annotator/utils/responsive.py
@@ -28,7 +28,7 @@ def get_dpi_scale() -> float:
     return logical_dpi / base_dpi
 
 
-def scale_value(value: int | float, dpi_scale: float = None) -> int:
+def scale_value(value: int | float, dpi_scale: float | None = None) -> int:
     """
     Scale a value based on DPI.
 
@@ -45,7 +45,7 @@ def scale_value(value: int | float, dpi_scale: float = None) -> int:
     return int(value * dpi_scale)
 
 
-def scale_font_size(base_size: int, dpi_scale: float = None) -> int:
+def scale_font_size(base_size: int, dpi_scale: float | None = None) -> int:
     """
     Scale font size based on DPI, with reasonable limits.
 
@@ -63,7 +63,9 @@ def scale_font_size(base_size: int, dpi_scale: float = None) -> int:
     return max(8, min(24, scaled))  # Clamp between 8-24pt
 
 
-def get_responsive_stylesheet_variables(dpi_scale: float = None) -> dict:
+def get_responsive_stylesheet_variables(
+    dpi_scale: float | None = None,
+) -> dict[str, str]:
     """
     Get stylesheet variables for responsive design.
 
@@ -87,7 +89,9 @@ def get_responsive_stylesheet_variables(dpi_scale: float = None) -> dict:
     }
 
 
-def apply_responsive_size_policy(widget, min_width: int = None, min_height: int = None):
+def apply_responsive_size_policy(
+    widget, min_width: int | None = None, min_height: int | None = None
+):
     """
     Apply responsive size policy to a widget.
 

--- a/src/clinical_dbs_annotator/utils/session_exporter.py
+++ b/src/clinical_dbs_annotator/utils/session_exporter.py
@@ -14,12 +14,13 @@ from datetime import datetime
 
 import pandas as pd
 from docx import Document
+from docx.document import Document as DocumentType
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from docx.shared import Inches
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QPainter, QPixmap
+from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QMessageBox, QWidget
 
 from .. import __app_name__, __version__
@@ -297,7 +298,7 @@ class SessionExporter:
 
     def _add_summary_section(
         self,
-        doc: Document,
+        doc: DocumentType,
         df: pd.DataFrame,
         df_initial: pd.DataFrame,
         df_final: pd.DataFrame,
@@ -338,7 +339,7 @@ class SessionExporter:
 
     def _add_programming_summary(
         self,
-        doc: Document,
+        doc: DocumentType,
         df: pd.DataFrame,
         df_initial: pd.DataFrame,
         df_final: pd.DataFrame,
@@ -356,10 +357,10 @@ class SessionExporter:
         duration_str = "N/A"
         try:
             if "time" in df.columns and "date" in df.columns:
-                timestamps = pd.to_datetime(
-                    df["date"].astype(str) + " " + df["time"].astype(str),
-                    errors="coerce",
-                ).dropna()
+                date_time_str = (
+                    df["date"].astype(str).str.cat(df["time"].astype(str), sep=" ")
+                )
+                timestamps = pd.to_datetime(date_time_str, errors="coerce").dropna()
             elif "time" in df.columns:
                 timestamps = pd.to_datetime(df["time"], errors="coerce").dropna()
             else:
@@ -558,7 +559,9 @@ class SessionExporter:
 
         return pd.DataFrame(lateral_data)
 
-    def _add_session_data_table(self, doc: Document, df_table: pd.DataFrame) -> None:
+    def _add_session_data_table(
+        self, doc: DocumentType, df_table: pd.DataFrame
+    ) -> None:
         """Add the lateral session-data table to the Word document."""
         doc.add_heading("Session Data", level=1)
 
@@ -604,9 +607,10 @@ class SessionExporter:
 
         # Define column widths in inches
         section = doc.sections[0]
-        page_width_inches = (
-            section.page_width - section.left_margin - section.right_margin
-        ) / 914400
+        page_width = int(section.page_width or 0)
+        left_margin = int(section.left_margin or 0)
+        right_margin = int(section.right_margin or 0)
+        page_width_inches = (page_width - left_margin - right_margin) / 914400
 
         base_in = {
             "laterality": 0.30,
@@ -777,7 +781,7 @@ class SessionExporter:
         self._add_table_legend(doc, best_block_ids, second_best_ids)
 
     def _add_table_legend(
-        self, doc: Document, best_ids: list, second_ids: list
+        self, doc: DocumentType, best_ids: list, second_ids: list
     ) -> None:
         """Add color legend and clinical disclaimer below the session data table."""
         from docx.shared import Pt, RGBColor
@@ -835,7 +839,7 @@ class SessionExporter:
         disclaimer_run.font.italic = True
 
     def _add_scales_timeline_chart(
-        self, doc: Document, lateral_df: pd.DataFrame
+        self, doc: DocumentType, lateral_df: pd.DataFrame
     ) -> None:
         """Add a rainbow-colored timeline chart of session scales with a general index line."""
         import math as _math
@@ -1069,7 +1073,7 @@ class SessionExporter:
             qbuf.open(QIODevice.OpenModeFlag.WriteOnly)
             pixmap.save(qbuf, "PNG")
             qbuf.close()
-            img_buf = BytesIO(bytes(qbuf.data()))
+            img_buf = BytesIO(qbuf.data().data())
             doc.add_picture(img_buf, width=Inches(6))
             doc.add_paragraph()
             img_buf.close()
@@ -1106,7 +1110,8 @@ class SessionExporter:
         if "block_id" in df.columns:
             try:
                 bid = pd.to_numeric(df["block_id"], errors="coerce")
-                return df.loc[bid.idxmax()]
+                max_idx = bid.idxmax()
+                return df.loc[[max_idx]].iloc[0]
             except Exception:
                 logger.debug(
                     "Fallback to last row after block_id parse failure", exc_info=True
@@ -1319,7 +1324,7 @@ class SessionExporter:
         canvas.contact_states.clear()
         canvas.case_state = ContactState.OFF
 
-        def apply_tokens(text: str, state: ContactState) -> None:
+        def apply_tokens(text: str, state: int) -> None:
             if not text:
                 return
             for token in str(text).split("_"):
@@ -1372,16 +1377,6 @@ class SessionExporter:
             pass
         self._apply_contact_tokens_to_canvas(canvas, anode_text, cathode_text)
 
-        # Force white background by temporarily overriding paintEvent
-        original_paint = canvas.paintEvent
-
-        def white_bg_paint(event):
-            painter = QPainter(canvas)
-            painter.fillRect(canvas.rect(), Qt.white)
-            original_paint(event)
-
-        canvas.paintEvent = white_bg_paint
-
         pixmap = QPixmap(canvas.size())
         pixmap.fill(Qt.white)
         canvas.render(pixmap)
@@ -1416,7 +1411,7 @@ class SessionExporter:
         return tmp.name
 
     def _add_electrode_config_section(
-        self, doc: Document, df: pd.DataFrame, df_initial: pd.DataFrame
+        self, doc: DocumentType, df: pd.DataFrame, df_initial: pd.DataFrame
     ) -> None:
         """Add the initial vs final electrode configuration images to the document."""
         if df is None or df.empty:
@@ -1577,10 +1572,11 @@ class SessionExporter:
             run.add_picture(img_path, width=Inches(1.15))
 
         for pth in paths.values():
-            try:
-                os.unlink(pth)
-            except Exception:
-                pass
+            if pth:
+                try:
+                    os.unlink(pth)
+                except Exception:
+                    pass
 
     def export_to_pdf(self, parent: QWidget | None = None, sections=None) -> bool:
         """Export session data to PDF by generating a Word report and converting it."""
@@ -1743,14 +1739,12 @@ class SessionExporter:
                 pd.to_numeric(df["is_initial"], errors="coerce").fillna(0).astype(int)
             )
 
-        df_initial = (
-            df[df.get("is_initial", 0) == 1]
-            if "is_initial" in df.columns
-            else df.iloc[0:0]
-        )
-        df_table = (
-            df[df.get("is_initial", 0) != 1] if "is_initial" in df.columns else df
-        )
+        if "is_initial" in df.columns:
+            df_initial = df[df["is_initial"] == 1]
+            df_table = df[df["is_initial"] != 1]
+        else:
+            df_initial = df.iloc[0:0]
+            df_table = df
 
         doc = Document()
 
@@ -1804,7 +1798,7 @@ class SessionExporter:
         doc.save(file_path)
         return True
 
-    def _add_report_footer(self, doc: Document) -> None:
+    def _add_report_footer(self, doc: DocumentType) -> None:
         """Add footer with patient ID and session number."""
         from docx.shared import Pt
 

--- a/src/clinical_dbs_annotator/utils/theme_manager.py
+++ b/src/clinical_dbs_annotator/utils/theme_manager.py
@@ -119,7 +119,7 @@ class ThemeManager:
 
         return re.sub(r"url\(([^)]+)\)", _resolve, content)
 
-    def apply_theme(self, theme: Theme, app: QApplication = None) -> None:
+    def apply_theme(self, theme: Theme, app: QApplication | None = None) -> None:
         """
         Apply a theme to the application.
 
@@ -131,7 +131,8 @@ class ThemeManager:
             ValueError: If app is None and no QApplication instance exists
         """
         if app is None:
-            app = QApplication.instance()
+            maybe_app = QApplication.instance()
+            app = maybe_app if isinstance(maybe_app, QApplication) else None
 
         if app is None:
             raise ValueError("No QApplication instance available")
@@ -157,7 +158,7 @@ class ThemeManager:
             tooltip_palette.setColor(QPalette.ColorRole.ToolTipText, QColor("#0f172a"))
         QToolTip.setPalette(tooltip_palette)
 
-    def toggle_theme(self, app: QApplication = None) -> Theme:
+    def toggle_theme(self, app: QApplication | None = None) -> Theme:
         """
         Toggle between dark and light themes.
 

--- a/src/clinical_dbs_annotator/views/base_view.py
+++ b/src/clinical_dbs_annotator/views/base_view.py
@@ -5,6 +5,7 @@ This module provides the base class that all step views inherit from,
 containing common functionality and UI elements.
 """
 
+from PySide6.QtCore import QByteArray
 from PySide6.QtGui import QIcon, QPixmap
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
@@ -42,7 +43,7 @@ class BaseStepView(QWidget):
         </svg>
         """
         pixmap = QPixmap()
-        pixmap.loadFromData(bytes(svg, encoding="utf-8"), "SVG")
+        pixmap.loadFromData(QByteArray(svg.encode("utf-8")))
         return QIcon(pixmap)
 
     def _get_theme_icon_color(self) -> str:

--- a/src/clinical_dbs_annotator/views/step1_view.py
+++ b/src/clinical_dbs_annotator/views/step1_view.py
@@ -9,6 +9,7 @@ import logging
 import os
 from collections.abc import Callable
 from datetime import datetime
+from typing import cast
 
 from PySide6.QtCore import QSize, Qt
 from PySide6.QtGui import QDoubleValidator, QIntValidator
@@ -19,6 +20,7 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QFormLayout,
     QFrame,
+    QGraphicsEffect,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -259,7 +261,7 @@ class Step1View(BaseStepView):
         self.left_stim_freq_edit.setMaximumWidth(80)
         self.left_stim_freq_edit.setPlaceholderText(PLACEHOLDERS["frequency"])
         self.left_stim_freq_edit.setValidator(
-            QIntValidator(freq_limits["min"], freq_limits["max"])
+            QIntValidator(int(freq_limits["min"]), int(freq_limits["max"]))
         )
         left_freq_widget = IncrementWidget(
             self.left_stim_freq_edit,
@@ -279,7 +281,9 @@ class Step1View(BaseStepView):
         self.left_amp_edit.setPlaceholderText(PLACEHOLDERS["amplitude"])
         self.left_amp_edit.setValidator(
             QDoubleValidator(
-                amp_limits["min"], amp_limits["max"], amp_limits["decimals"]
+                float(amp_limits["min"]),
+                float(amp_limits["max"]),
+                int(amp_limits["decimals"]),
             )
         )
         left_amp_widget = IncrementWidget(
@@ -299,7 +303,7 @@ class Step1View(BaseStepView):
         self.left_pw_edit.setMaximumWidth(80)
         self.left_pw_edit.setPlaceholderText(PLACEHOLDERS["pulse_width"])
         self.left_pw_edit.setValidator(
-            QIntValidator(pw_limits["min"], pw_limits["max"])
+            QIntValidator(int(pw_limits["min"]), int(pw_limits["max"]))
         )
         left_pw_widget = IncrementWidget(
             self.left_pw_edit,
@@ -344,7 +348,7 @@ class Step1View(BaseStepView):
         self.right_stim_freq_edit.setMaximumWidth(80)
         self.right_stim_freq_edit.setPlaceholderText(PLACEHOLDERS["frequency"])
         self.right_stim_freq_edit.setValidator(
-            QIntValidator(freq_limits["min"], freq_limits["max"])
+            QIntValidator(int(freq_limits["min"]), int(freq_limits["max"]))
         )
         right_freq_widget = IncrementWidget(
             self.right_stim_freq_edit,
@@ -364,7 +368,9 @@ class Step1View(BaseStepView):
         self.right_amp_edit.setPlaceholderText(PLACEHOLDERS["amplitude"])
         self.right_amp_edit.setValidator(
             QDoubleValidator(
-                amp_limits["min"], amp_limits["max"], amp_limits["decimals"]
+                float(amp_limits["min"]),
+                float(amp_limits["max"]),
+                int(amp_limits["decimals"]),
             )
         )
         right_amp_widget = IncrementWidget(
@@ -384,7 +390,7 @@ class Step1View(BaseStepView):
         self.right_pw_edit.setMaximumWidth(80)
         self.right_pw_edit.setPlaceholderText(PLACEHOLDERS["pulse_width"])
         self.right_pw_edit.setValidator(
-            QIntValidator(pw_limits["min"], pw_limits["max"])
+            QIntValidator(int(pw_limits["min"]), int(pw_limits["max"]))
         )
         right_pw_widget = IncrementWidget(
             self.right_pw_edit,
@@ -702,7 +708,7 @@ class Step1View(BaseStepView):
         canvas.contact_states.clear()
         canvas.case_state = ContactState.OFF
 
-        def apply_tokens(text: str, state: ContactState) -> None:
+        def apply_tokens(text: str, state: int) -> None:
             if not text:
                 return
             for token in text.split("_"):
@@ -921,7 +927,7 @@ class Step1View(BaseStepView):
                     effect.setOpacity(0.3)
                     widget.setGraphicsEffect(effect)
                 else:
-                    widget.setGraphicsEffect(None)
+                    widget.setGraphicsEffect(cast("QGraphicsEffect", None))
         elif side == "right":
             self.right_electrode_enabled = checked
             self.right_group.setEnabled(checked)
@@ -932,7 +938,7 @@ class Step1View(BaseStepView):
                     effect.setOpacity(0.3)
                     widget.setGraphicsEffect(effect)
                 else:
-                    widget.setGraphicsEffect(None)
+                    widget.setGraphicsEffect(cast("QGraphicsEffect", None))
 
     def _create_notes_group(self) -> QGroupBox:
         """Create the initial notes group box."""
@@ -1434,7 +1440,7 @@ class Step1View(BaseStepView):
             self.current_file_mode = "new"
             self.next_block_id = None
 
-    def get_preset_button(self, preset_name: str) -> QPushButton:
+    def get_preset_button(self, preset_name: str) -> QPushButton | None:
         """Get a preset button by name."""
         return self.findChild(QPushButton, f"preset_{preset_name}")
 
@@ -1656,8 +1662,8 @@ class Step1View(BaseStepView):
         value: str = "",
         with_plus: bool = False,
         with_minus: bool = False,
-        on_add: Callable = None,
-        on_remove: Callable = None,
+        on_add: Callable[[], None] | None = None,
+        on_remove: Callable[[QHBoxLayout], None] | None = None,
     ) -> None:
         """Add a single clinical scale row."""
         row = QHBoxLayout()

--- a/src/clinical_dbs_annotator/views/step2_view.py
+++ b/src/clinical_dbs_annotator/views/step2_view.py
@@ -131,7 +131,7 @@ class Step2View(BaseStepView):
 
         return gb_session
 
-    def get_preset_button(self, preset_name: str) -> QPushButton:
+    def get_preset_button(self, preset_name: str) -> QPushButton | None:
         """Get a preset button by name."""
         return self.findChild(QPushButton, f"preset2_{preset_name}")
 
@@ -388,8 +388,8 @@ class Step2View(BaseStepView):
         maxval: str = "",
         with_plus: bool = False,
         with_minus: bool = False,
-        on_add: Callable = None,
-        on_remove: Callable = None,
+        on_add: Callable[[], None] | None = None,
+        on_remove: Callable[[QHBoxLayout], None] | None = None,
     ) -> None:
         """Add a single session scale row (name, min, max)."""
         row = QHBoxLayout()

--- a/src/clinical_dbs_annotator/views/step3_view.py
+++ b/src/clinical_dbs_annotator/views/step3_view.py
@@ -6,6 +6,7 @@ session data including stimulation parameters and scale values.
 """
 
 import logging
+from typing import cast
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QDoubleValidator, QIntValidator
@@ -15,6 +16,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QFrame,
+    QGraphicsEffect,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -77,7 +79,7 @@ class Step3View(BaseStepView):
         super().__init__()
         # parent_style is now set in BaseStepView.__init__
         self.session_scale_value_edits = []
-        self.step3_session_scales_form: QFormLayout = None
+        self.step3_session_scales_form: QFormLayout | None = None
 
         self.left_canvas = ElectrodeCanvas()
         self.right_canvas = ElectrodeCanvas()
@@ -232,7 +234,7 @@ class Step3View(BaseStepView):
         self.session_left_stim_freq_edit.setMaximumWidth(80)
         self.session_left_stim_freq_edit.setPlaceholderText(PLACEHOLDERS["frequency"])
         self.session_left_stim_freq_edit.setValidator(
-            QIntValidator(freq_limits["min"], freq_limits["max"])
+            QIntValidator(int(freq_limits["min"]), int(freq_limits["max"]))
         )
         left_freq_widget = IncrementWidget(
             self.session_left_stim_freq_edit,
@@ -252,7 +254,9 @@ class Step3View(BaseStepView):
         self.session_left_amp_edit.setPlaceholderText(PLACEHOLDERS["amplitude"])
         self.session_left_amp_edit.setValidator(
             QDoubleValidator(
-                amp_limits["min"], amp_limits["max"], amp_limits["decimals"]
+                float(amp_limits["min"]),
+                float(amp_limits["max"]),
+                int(amp_limits["decimals"]),
             )
         )
         left_amp_widget = IncrementWidget(
@@ -272,7 +276,7 @@ class Step3View(BaseStepView):
         self.session_left_pw_edit.setMaximumWidth(80)
         self.session_left_pw_edit.setPlaceholderText(PLACEHOLDERS["pulse_width"])
         self.session_left_pw_edit.setValidator(
-            QIntValidator(pw_limits["min"], pw_limits["max"])
+            QIntValidator(int(pw_limits["min"]), int(pw_limits["max"]))
         )
         left_pw_widget = IncrementWidget(
             self.session_left_pw_edit,
@@ -317,7 +321,7 @@ class Step3View(BaseStepView):
         self.session_right_stim_freq_edit.setMaximumWidth(80)
         self.session_right_stim_freq_edit.setPlaceholderText(PLACEHOLDERS["frequency"])
         self.session_right_stim_freq_edit.setValidator(
-            QIntValidator(freq_limits["min"], freq_limits["max"])
+            QIntValidator(int(freq_limits["min"]), int(freq_limits["max"]))
         )
         right_freq_widget = IncrementWidget(
             self.session_right_stim_freq_edit,
@@ -337,7 +341,9 @@ class Step3View(BaseStepView):
         self.session_right_amp_edit.setPlaceholderText(PLACEHOLDERS["amplitude"])
         self.session_right_amp_edit.setValidator(
             QDoubleValidator(
-                amp_limits["min"], amp_limits["max"], amp_limits["decimals"]
+                float(amp_limits["min"]),
+                float(amp_limits["max"]),
+                int(amp_limits["decimals"]),
             )
         )
         right_amp_widget = IncrementWidget(
@@ -357,7 +363,7 @@ class Step3View(BaseStepView):
         self.session_right_pw_edit.setMaximumWidth(80)
         self.session_right_pw_edit.setPlaceholderText(PLACEHOLDERS["pulse_width"])
         self.session_right_pw_edit.setValidator(
-            QIntValidator(pw_limits["min"], pw_limits["max"])
+            QIntValidator(int(pw_limits["min"]), int(pw_limits["max"]))
         )
         right_pw_widget = IncrementWidget(
             self.session_right_pw_edit,
@@ -700,7 +706,7 @@ class Step3View(BaseStepView):
                     effect.setOpacity(0.3)
                     widget.setGraphicsEffect(effect)
                 else:
-                    widget.setGraphicsEffect(None)
+                    widget.setGraphicsEffect(cast("QGraphicsEffect", None))
         elif side == "right":
             self.right_electrode_enabled = checked
             self.right_group.setEnabled(checked)
@@ -711,7 +717,7 @@ class Step3View(BaseStepView):
                     effect.setOpacity(0.3)
                     widget.setGraphicsEffect(effect)
                 else:
-                    widget.setGraphicsEffect(None)
+                    widget.setGraphicsEffect(cast("QGraphicsEffect", None))
 
     def _create_session_notes_group(self) -> QGroupBox:
         gb_notes = QGroupBox("Session notes")

--- a/src/clinical_dbs_annotator/views/wizard_window.py
+++ b/src/clinical_dbs_annotator/views/wizard_window.py
@@ -8,6 +8,7 @@ navigation, and coordinates views with the controller.
 import logging
 import os
 import typing
+from typing import Protocol
 
 from PySide6.QtCore import QSize, Qt
 from PySide6.QtGui import QIcon, QPixmap
@@ -52,6 +53,14 @@ from .step2_view import Step2View
 from .step3_view import Step3View
 
 logger = logging.getLogger(__name__)
+
+
+class _HeaderTitleProvider(Protocol):
+    def get_header_title(self) -> str: ...
+
+
+class _HeaderSubtitleProvider(Protocol):
+    def get_header_subtitle(self) -> str: ...
 
 
 class WizardWindow(QWidget):
@@ -265,7 +274,8 @@ class WizardWindow(QWidget):
 
         if hasattr(current, "get_header_title"):
             try:
-                return str(current.get_header_title() or "")
+                provider = typing.cast(_HeaderTitleProvider, current)
+                return str(provider.get_header_title() or "")
             except Exception:
                 return ""
 
@@ -288,7 +298,8 @@ class WizardWindow(QWidget):
 
         if hasattr(current, "get_header_subtitle"):
             try:
-                return str(current.get_header_subtitle() or "")
+                provider = typing.cast(_HeaderSubtitleProvider, current)
+                return str(provider.get_header_subtitle() or "")
             except Exception:
                 return ""
 
@@ -412,7 +423,8 @@ class WizardWindow(QWidget):
         self.workflow_mode = "full"
         self.current_step = 1
         self._load_full_workflow_views()
-        self.stack.setCurrentWidget(self.step1_view)
+        if self.step1_view is not None:
+            self.stack.setCurrentWidget(self.step1_view)
         self._update_window_size_for_main_workflow()  # Resize to normal size
         self._update_ui_state()
 
@@ -421,7 +433,8 @@ class WizardWindow(QWidget):
         self.workflow_mode = "annotations_only"
         self.current_step = 1
         self._load_annotations_only_views()
-        self.stack.setCurrentWidget(self.annotations_file_view)
+        if self.annotations_file_view is not None:
+            self.stack.setCurrentWidget(self.annotations_file_view)
         self._update_window_size_for_main_workflow()  # Resize to normal size
         self._update_ui_state()
 
@@ -430,7 +443,8 @@ class WizardWindow(QWidget):
         self.workflow_mode = "longitudinal"
         self.current_step = 1
         self._load_longitudinal_views()
-        self.stack.setCurrentWidget(self.longitudinal_file_view)
+        if self.longitudinal_file_view is not None:
+            self.stack.setCurrentWidget(self.longitudinal_file_view)
         self._update_window_size_for_main_workflow()
         self._update_ui_state()
 

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ name = "appscript"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml" },
+    { name = "lxml", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/52/2fa70edfd98f0058219ecc2e365a3ba7aabd42db14ff9d7f44bbdcc5400d/appscript-1.4.0.tar.gz", hash = "sha256:b2c6fc770bf822ea45529c7084bc0ee340e67ab260016b01d28e0449ec8723be", size = 295279, upload-time = "2025-10-08T07:56:39.126Z" }
 wheels = [
@@ -135,11 +135,13 @@ build = [
     { name = "pyinstaller" },
 ]
 dev = [
+    { name = "pandas-stubs" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 docs = [
     { name = "sphinx" },
@@ -164,11 +166,13 @@ build = [
     { name = "pyinstaller", specifier = ">=6.15.0" },
 ]
 dev = [
+    { name = "pandas-stubs", specifier = ">=3.0.0.260204" },
     { name = "pre-commit", specifier = ">=3.6" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-qt", specifier = ">=4.4.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "ty", specifier = ">=0.0.30" },
 ]
 docs = [
     { name = "sphinx", specifier = ">=9.0.4" },
@@ -496,6 +500,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
     { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
     { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.0.260204"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/2f/f91e4eee21585ff548e83358332d5632ee49f6b2dcd96cb5dca4e0468951/pandas_stubs-3.0.0.260204-py3-none-any.whl", hash = "sha256:5ab9e4d55a6e2752e9720828564af40d48c4f709e6a2c69b743014a6fcb6c241", size = 168540, upload-time = "2026-02-04T15:17:15.615Z" },
 ]
 
 [[package]]
@@ -1038,6 +1054,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/21/3ee32f163038ac2663c7bea47a07d06bf4cc7c09d95b96db194bda1b70cb/ty-0.0.30.tar.gz", hash = "sha256:c982207640e7d75331b81031ebfb884ab858ed26ab16d7c086ac4942e2771846", size = 5518350, upload-time = "2026-04-14T13:53:35.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/24/7aa94d02a9257ed96e64e4e99b527f28390febd8424107b4f8a70763ace9/ty-0.0.30-py3-none-linux_armv6l.whl", hash = "sha256:1be31a24a2a177571c3276854bf01b2b1a77dba6e754507089c25bb1825ce5f6", size = 10801835, upload-time = "2026-04-14T13:53:21.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/97/2410ebc85cfcdf3bbd0e5958c6cd0b88085b1a184374ecfa755f84d6c8b2/ty-0.0.30-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:019f1d0d5d5265a1e634a51fd49374df43dafae14de98c2a0d349beb8233550b", size = 10582386, upload-time = "2026-04-14T13:53:07.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d2/a2649eb6841ebf946ac827e778b7e78b5ef63c3758bf2b9da13d927a53da/ty-0.0.30-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe3012af4d0714e7353fd3cf6d2d02d5b0f0fe6f1cb8beb2366ed9f621c2c349", size = 10031621, upload-time = "2026-04-14T13:53:01.523Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8e/40a66ccd5d5d51adf0469b9fbe4f1f79f928a880b34b8a6c7c934e8a883a/ty-0.0.30-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1e90b4ebf6310c7734344739e0950f4cede5a33b1e51a12a0c0fc8a975866ed", size = 10537511, upload-time = "2026-04-14T13:53:04.538Z" },
+    { url = "https://files.pythonhosted.org/packages/25/31/5dea2987601ef1c8c58b04f2173971e7fe51f7902ab93a66d09e0f12115a/ty-0.0.30-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd83a0d82cbc32c2ae521e7fa101fb5fe5b566adb1364996582535700572a9ec", size = 10603406, upload-time = "2026-04-14T13:53:47.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a4/5a7585b6b219a2edc00255af0b16a8475f88fe43c5cdbe499daecb67f100/ty-0.0.30-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:672a29271c13247096d0b2766e69cb35b1583882dd6e7b24065927e2491ffe6d", size = 11109133, upload-time = "2026-04-14T13:53:24.463Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/83/b402dc4bd99b6f3eb0bce04e557889a164e099976a7fc71a6b07c923241b/ty-0.0.30-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91ff236adbb90281c05f7e160664820be50f42d3a9d8f1d0a648f006864114fa", size = 11663362, upload-time = "2026-04-14T13:53:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1b/8157f03acc15421083c194b11a61a78d10e3dfa7e4a0177809fc9acc3881/ty-0.0.30-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ec99bd5d5430c52fb64038483deb070f12c7ae78ffd6d6841d31719daedf1d7", size = 11304786, upload-time = "2026-04-14T13:53:30.076Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c3/f89a9a42b47da108ed758ae9d065d10bf2acc2ea88e3d200b95511096b7b/ty-0.0.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4b328ee332ec6276afc863ea7cf6d8167d9dd8d9f3d1c2e738ef39932511ac4", size = 11173426, upload-time = "2026-04-14T13:53:10.262Z" },
+    { url = "https://files.pythonhosted.org/packages/81/37/fa38ee0259dc49579e1871b23ab1ff27331a78460566cdc13045a237595d/ty-0.0.30-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd0d664d6530890a8e872accd96895410773e7a4c6d20c244fb7a5f541ff359b", size = 10517157, upload-time = "2026-04-14T13:53:15.739Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/79/28032481141eb6ce3274f62b9ff9b1d73d59df6b28080c8fe3c6bdef700e/ty-0.0.30-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:314004166a7a5e39e169c7da0b9e78f3315382f53db8698fd98346cee3bb0784", size = 10613222, upload-time = "2026-04-14T13:53:13.269Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a0/989fca4c74095defd7d3ba5afc68a5aa4e2ca428fedfca5df526701c730b/ty-0.0.30-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d969ebf9d8b08e93e638c56e6fb5a8dacd2a24f43e3519479d245ddde69f968e", size = 10789624, upload-time = "2026-04-14T13:53:42.156Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/74/3e74aba392ba2eeae5d86568ee282d9d6b2b6642445e3d9837c88d73c282/ty-0.0.30-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:66922c8c4381a016f90ec4b811748e7bb12da892f4c273640710da721caea7fb", size = 11260273, upload-time = "2026-04-14T13:53:44.974Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0e/e94a0e5e5a1850a2ba61c5efcfa594cfc2d23c026bf431cce33003d036a0/ty-0.0.30-py3-none-win32.whl", hash = "sha256:b7b2ecf80c872d7d9928b372e99233bdda7cabe639edd06b6232c3161a7dfa40", size = 10145096, upload-time = "2026-04-14T13:53:39.335Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/09c8df72ad37f7f4d9d79fe04a08bfa649d9f141d137e624fc23c7c3d7fe/ty-0.0.30-py3-none-win_amd64.whl", hash = "sha256:f29834e3d96c447f2adcf9eeb55b3f92005c91f52597c4c46d844188ec67ec72", size = 11156009, upload-time = "2026-04-14T13:53:32.847Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/17/a5c049c36e2fef9c593a1862f275af963b66045378f10b6908c6f10f6f4a/ty-0.0.30-py3-none-win_arm64.whl", hash = "sha256:d9be1d258dab615b447d20fa58633f0ae163af01bfa781a50457defec20642fd", size = 10552887, upload-time = "2026-04-14T13:53:27.455Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Added typing tooling/deps in pyproject.toml
- Added pandas-stubs to dev dependencies.
- Kept ty in dev dependencies.
- Added global ty rule config: unresolved-attribute = "ignore"
- Added/updated type hints and type-safety fixes across source files:
- Integrated pre-commit typing
- Updated .pre-commit-config.yaml with a local hook
- Integrated CI typing as a second job in same workflow
  - added new type-check job 
- Bugs discovered and fixed
- Real syntax bug: multiple files used legacy Python 2 exception syntax (except A, B:), which is invalid in Python 3. Fixed to except (A, B): in affected files (controllers/views/utils/ui).
- Potential runtime typing issues fixed:
  - Safer handling of optional file paths before open()/unlink().
  - DataFrame indexing/selection paths adjusted to avoid ambiguous Series | DataFrame behavior in exporter logic.
  - Explicit typing around Qt/pandas boundaries where inference was too loose.
- Unsolvable / constrained typing issues
  - The major remaining ecosystem limitation is PySide6 attribute resolution noise (enum/attribute surface and dynamic Qt patterns), which generated high-volume false positives under ty.
  - Temporarily added unresolved-attribute = "ignore"
  
  Addresses #32 